### PR TITLE
Fix publiccode.yml

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -6,7 +6,11 @@ publiccodeYmlVersion: '0.2'
 name: BABEL
 applicationSuite: BABEL
 url: 'https://github.com/Azienda-USL-di-Bologna/babel'
+<<<<<<< HEAD
 releaseDate:'2019-04-01'
+=======
+releaseDate: '2019-04-01'
+>>>>>>> Fix publiccode.yml, changed file names
 developmentStatus: stable
 platforms:
   - web
@@ -40,10 +44,17 @@ maintenance:
   contractors:
     - until: '2022-06-30'
       name: NEXT srl
+<<<<<<< HEAD
       website: 'https://www.nextsw.it'
     - name: NSI srl
       until: '2022-06-30'
       website: 'https://www.nsi.it'
+=======
+      website: 'https://nextsw.it'
+    - name: NSI srl
+      until: '2022-06-30'
+      website: 'http://www.nsi.it'
+>>>>>>> Fix publiccode.yml, changed file names
 legal:
   license: EUPL-1.2
   repoOwner: Azienda USL di Bologna
@@ -115,11 +126,19 @@ description:
       - 'Scrivania: Log di utilizzo'
       - 'PEC Internauta: possibilità di protocollare una mail in ingresso'
       - 'PEC Internauta: possibilità di immettere una mail in un fascicolo'
+<<<<<<< HEAD
       - 'PEC Internauta: Reindirizzamento di PEC ad altra casella con mantenimento metadati'
       - 'PEC Internauta: Associazione diretta ricevute alle PEC che le hanno generate'
       - 'PEC Internauta: Gestione particolare degli errori di invio'
       - 'BABORG: configurazione delle articolazioni organizzative servizi unificati tra Enti'
       - 'BABORG: Gestione dell'anagrafe PEC e loro mappatura sugli organigrammi degli Enti'
+=======
+      - 'PEC Internauta: Reindirizzamento di mail ad altra casella con mantenimento metadati'
+      - 'PEC Internauta: Associazione diretta ricevute alle mail inviate che le hanno generate'
+      - 'PEC Internauta: Gestione particolare degli errori di invio'
+      - 'BABORG: configurazione articolazioni organizzative unificate tra Enti diversi'
+      - "BABORG: Gestione dell'anagrafe PEC e loro mappatura sugli organigrammi degli Enti"
+>>>>>>> Fix publiccode.yml, changed file names
     screenshots:
       - 'Scrivania_Internauta.jpg'
       - 'Pec_Internauta.jpg'

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -6,11 +6,7 @@ publiccodeYmlVersion: '0.2'
 name: BABEL
 applicationSuite: BABEL
 url: 'https://github.com/Azienda-USL-di-Bologna/babel'
-<<<<<<< HEAD
-releaseDate:'2019-04-01'
-=======
 releaseDate: '2019-04-01'
->>>>>>> Fix publiccode.yml, changed file names
 developmentStatus: stable
 platforms:
   - web
@@ -44,17 +40,10 @@ maintenance:
   contractors:
     - until: '2022-06-30'
       name: NEXT srl
-<<<<<<< HEAD
-      website: 'https://www.nextsw.it'
-    - name: NSI srl
-      until: '2022-06-30'
-      website: 'https://www.nsi.it'
-=======
       website: 'https://nextsw.it'
     - name: NSI srl
       until: '2022-06-30'
       website: 'http://www.nsi.it'
->>>>>>> Fix publiccode.yml, changed file names
 legal:
   license: EUPL-1.2
   repoOwner: Azienda USL di Bologna
@@ -126,19 +115,11 @@ description:
       - 'Scrivania: Log di utilizzo'
       - 'PEC Internauta: possibilità di protocollare una mail in ingresso'
       - 'PEC Internauta: possibilità di immettere una mail in un fascicolo'
-<<<<<<< HEAD
-      - 'PEC Internauta: Reindirizzamento di PEC ad altra casella con mantenimento metadati'
-      - 'PEC Internauta: Associazione diretta ricevute alle PEC che le hanno generate'
-      - 'PEC Internauta: Gestione particolare degli errori di invio'
-      - 'BABORG: configurazione delle articolazioni organizzative servizi unificati tra Enti'
-      - 'BABORG: Gestione dell'anagrafe PEC e loro mappatura sugli organigrammi degli Enti'
-=======
       - 'PEC Internauta: Reindirizzamento di mail ad altra casella con mantenimento metadati'
       - 'PEC Internauta: Associazione diretta ricevute alle mail inviate che le hanno generate'
       - 'PEC Internauta: Gestione particolare degli errori di invio'
       - 'BABORG: configurazione articolazioni organizzative unificate tra Enti diversi'
       - "BABORG: Gestione dell'anagrafe PEC e loro mappatura sugli organigrammi degli Enti"
->>>>>>> Fix publiccode.yml, changed file names
     screenshots:
       - 'Scrivania_Internauta.jpg'
       - 'Pec_Internauta.jpg'


### PR DESCRIPTION
Buongiorno @babel-auslbo,
questa PR:

* riduce la lunghezza di alcune features per rispettare il numero massimo di caratteri consentito (100). 
* cambia il formato della data.
* cambia il protocollo in `https` per il website dei contractors.
* cambia i nomi dei file immagine.
* cambia i percorsi di tali immagini nel publiccode.

NB: al momento, c'è ancora un problema dato dal sito del contractor (`https://nextsw.it`) in quanto c'è un problema sulla chain del certificato. Per maggior informazioni è possibile vedere il risultato della scansione qui: https://www.ssllabs.com/ssltest/analyze.html?d=nextsw.it
Finchè questo non verrà risolto, la scheda non sarà indicizzata. 
Consiglio: siccome il campo `website` non è obbligatorio, consiglierei di eliminare tale voce in modo da avere la scheda indicizzata nel catalogo e, una volta che il problema con il certificato sarà risolto, sarà possibile inserire nuovamente il link nel publiccode.
Resto a disposizione.
Grazie molte!